### PR TITLE
Fix ascend, split out find_caller_of and test it

### DIFF
--- a/src/backedges.jl
+++ b/src/backedges.jl
@@ -1,6 +1,6 @@
 # A lightly-modified version of the same function in Base
 # Highlights argument types with color specified by highlighter(typ)
-function show_tuple_as_call(@nospecialize(highlighter), io::IO, name::Symbol, sig::Type, demangle=false, kwargs=nothing)
+function show_tuple_as_call(@nospecialize(highlighter), io::IO, name::Symbol, @nospecialize(sig::Type), demangle=false, kwargs=nothing)
     if sig === Tuple
         print(io, demangle ? Base.demangle_function_name(name) : name, "(...)")
         return

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -234,6 +234,7 @@ end
 
 is_callsite(cs::Callsite, mi::MethodInstance) = is_callsite(cs.info, mi)
 is_callsite(info::MICallInfo, mi::MethodInstance) = info.mi == mi
+is_callsite(info::ConstPropCallInfo, mi::MethodInstance) = is_callsite(info.mi, mi)
 is_callsite(info::DeoptimizedCallInfo, mi::MethodInstance) = is_callsite(info.accurate, mi)
 is_callsite(info::TaskCallInfo, mi::MethodInstance) = is_callsite(info.ci, mi)
 is_callsite(info::ReturnTypeCallInfo, mi::MethodInstance) = is_callsite(info.called_mi, mi)


### PR DESCRIPTION
This updates `ascend` to work with the new internals. This also splits out a bit more of the internals to make them more testable (the UI code is a pain to write tests for).

@chriselrod, this should address a wish-list item of yours on discourse: not only does this fix ascend, but I took the opportunity to provide better support for inlining in stacktraces. With this setup:
```julia
julia> using Cthulhu

julia> bt = try
           [sqrt(x) for x in [1, -1]]
       catch
           catch_backtrace()
       end;

julia> ascend(bt)
Choose a call for analysis (q to quit):
     throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:33
 >     sqrt at ./math.jl:535 => sqrt at ./math.jl:1181 => #11 at ./none:0 => iterate at ./generator.jl:47 => collect_to! at ./array.jl:725 => collect_to_with_first!(::Vector{Float64}, ::Float64, ::Base.G
         collect(::Base.Generator{Vector{Int64}, var"#11#12"}) at ./array.jl:684
           eval at ./boot.jl:369 => eval_user_input(::Any, ::REPL.REPLBackend) at /home/tim/src/julia-master/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:139
             repl_backend_loop(::REPL.REPLBackend) at /home/tim/src/julia-master/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:200
               start_repl_backend(::REPL.REPLBackend, ::Any) at /home/tim/src/julia-master/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:185
                 #run_repl#42(::Bool, ::typeof(REPL.run_repl), ::REPL.AbstractREPL, ::Any) at /home/tim/src/julia-master/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:317
                   run_repl(::REPL.AbstractREPL, ::Any) at /home/tim/src/julia-master/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:305
                     (::Base.var"#916#918"{Bool, Bool, Bool})(::Module) at ./client.jl:394
v                      #invokelatest#2 at ./essentials.jl:734 => invokelatest at ./essentials.jl:732 => run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at ./client.jl:379
```
now when you press enter when the `>` is positioned as above, you get this:
```julia
Choose caller of MethodInstance for Base.Math.throw_complex_domainerror(::Symbol, ::Float64) or proceed to typed code:
 > "array.jl", collect_to_with_first!: lines [703]
    "array.jl", collect_to!: lines [725]
     "generator.jl", iterate: lines [47]
       "math.jl", sqrt: lines [1181, 535]
   Browse typed code
```
The successive indentation shows the sequence of calls that led to `throw_complex_domainerror` and you can select any of them for opening in your editor.