### PR TITLE
propagate TTY displaysize

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -377,7 +377,8 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
                     str = let debuginfo=debuginfo, src=src, codeinf=codeinf, rt=rt, mi=mi,
                               iswarn=iswarn, hide_type_stable=hide_type_stable,
                               remarks=_remarks, inline_cost=inline_cost, type_annotations=type_annotations
-                        stringify() do io # eliminate trailing indentation (see first item in bullet list in PR #189)
+                        ioctx = IOContext(iostream, :color=>true, :displaysize=>displaysize(iostream)) # displaysize doesn't propagate otherwise
+                        stringify(ioctx) do io
                             lambda_io = IOContext(io, :SOURCE_SLOTNAMES => Base.sourceinfo_slotnames(codeinf))
                             cthulhu_typed(lambda_io, debuginfo, src, rt, mi;
                                           iswarn, hide_type_stable,
@@ -385,6 +386,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
                                           interp)
                         end
                     end
+                    # eliminate trailing indentation (see first item in bullet list in PR #189)
                     rmatch = findfirst(r"\u001B\[90m\u001B\[(\d+)G( *)\u001B\[1G\u001B\[39m\u001B\[90m( *)\u001B\[39m$", str)
                     if rmatch !== nothing
                         str = str[begin:prevind(str, first(rmatch))]

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -113,8 +113,7 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
     debuginfo = IRShow.debuginfo(debuginfo)
     lineprinter = __debuginfo[debuginfo]
     rettype = ignorelimited(rt)
-    iolim = IOContext(io, :limit=>true)
-    lambda_io = iolim
+    lambda_io = IOContext(io, :limit=>true)
 
     if isa(src, Core.CodeInfo)
         # we're working on pre-optimization state, need to ignore `LimitedAccuracy`
@@ -131,12 +130,12 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
 
     if iswarn
         print(io, "Body")
-        InteractiveUtils.warntype_type_printer(iolim, rettype, true)
+        InteractiveUtils.warntype_type_printer(lambda_io, rettype, true)
         println(io)
     else
         isa(mi, MethodInstance) || throw("`mi::MethodInstance` is required")
         print(io, "│ ─ ")
-        println(iolim, Callsite(-1, MICallInfo(mi, rettype, Effects()), :invoke))
+        println(lambda_io, Callsite(-1, MICallInfo(mi, rettype, Effects()), :invoke))
     end
 
     # preprinter configuration

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -47,39 +47,42 @@ end
 TerminalMenus.options(m::CthulhuMenu) = m.options
 TerminalMenus.cancel(m::CthulhuMenu) = m.selected = -1
 
-function stringify(@nospecialize(f), io::IO=IOBuffer())
-    f(IOContext(io, :color=>true))
-    return String(take!(io))
+stringify(@nospecialize(f), io::IO = devnull) = stringify(f, IOContext(io, :color=>true))
+function stringify(@nospecialize(f), context::IOContext)
+    buf = IOBuffer()
+    io = IOContext(buf, context)
+    f(io)
+    return String(take!(buf))
 end
 
 const debugcolors = (:nothing, :light_black, :yellow)
 function usage(@nospecialize(view_cmd), optimize, iswarn, hide_type_stable, debuginfo, remarks, with_effects, inline_cost, type_annotations, highlight)
-    colorize(iotmp, use_color::Bool, c::Char) = stringify(iotmp) do io
+    colorize(use_color::Bool, c::Char) = stringify() do io
         use_color ? printstyled(io, c; color=:cyan) : print(io, c)
     end
 
-    io, iotmp = IOBuffer(), IOBuffer()
+    io = IOBuffer()
     ioctx = IOContext(io, :color=>true)
 
     println(ioctx, "Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.")
     println(ioctx, "Toggles: [",
-        colorize(iotmp, optimize, 'o'), "]ptimize, [",
-        colorize(iotmp, iswarn, 'w'), "]arn, [",
-        colorize(iotmp, hide_type_stable, 'h'), "]ide type-stable statements, [",
-        stringify(iotmp) do io
+        colorize(optimize, 'o'), "]ptimize, [",
+        colorize(iswarn, 'w'), "]arn, [",
+        colorize(hide_type_stable, 'h'), "]ide type-stable statements, [",
+        stringify() do io
             printstyled(io, 'd'; color=debugcolors[Int(debuginfo)+1])
         end, "]ebuginfo, [",
-        colorize(iotmp, remarks, 'r'), "]emarks, [",
-        colorize(iotmp, with_effects, 'e'), "]ffects, [",
-        colorize(iotmp, inline_cost, 'i'), "]nlining costs, [",
-        colorize(iotmp, type_annotations, 't'), "]ype annotations, [",
-        colorize(iotmp, highlight, 's'), "]yntax highlight for Source/LLVM/Native.")
+        colorize(remarks, 'r'), "]emarks, [",
+        colorize(with_effects, 'e'), "]ffects, [",
+        colorize(inline_cost, 'i'), "]nlining costs, [",
+        colorize(type_annotations, 't'), "]ype annotations, [",
+        colorize(highlight, 's'), "]yntax highlight for Source/LLVM/Native.")
     println(ioctx, "Show: [",
-        colorize(iotmp, view_cmd === cthulhu_source, 'S'), "]ource code, [",
-        colorize(iotmp, view_cmd === cthulhu_ast, 'A'), "]ST, [",
-        colorize(iotmp, view_cmd === cthulhu_typed, 'T'), "]yped code, [",
-        colorize(iotmp, view_cmd === cthulhu_llvm, 'L'), "]LVM IR, [",
-        colorize(iotmp, view_cmd === cthulhu_native, 'N'), "]ative code")
+        colorize(view_cmd === cthulhu_source, 'S'), "]ource code, [",
+        colorize(view_cmd === cthulhu_ast, 'A'), "]ST, [",
+        colorize(view_cmd === cthulhu_typed, 'T'), "]yped code, [",
+        colorize(view_cmd === cthulhu_llvm, 'L'), "]LVM IR, [",
+        colorize(view_cmd === cthulhu_native, 'N'), "]ative code")
     print(ioctx,
     """
     Actions: [E]dit source code, [R]evise and redisplay


### PR DESCRIPTION
Currently `displaysize` configuration of TTY terminals are not respected, and so the inline source location printing appears to be a bit weird:
> before
<img width="1324" alt="Screen Shot 2022-02-28 at 12 21 11" src="https://user-images.githubusercontent.com/40514306/155918676-c6b9aafb-46e2-438d-907d-c3ab88c1a2f1.png">


With this PR, we get a reasonable a location printing:
> after
<img width="1324" alt="Screen Shot 2022-02-28 at 12 20 44" src="https://user-images.githubusercontent.com/40514306/155918667-7210afaf-3ab4-45a7-940f-465c1237fa75.png">
