### PR TITLE
`get_effects()` should pull from optimized cache if `optimize == true`

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -162,7 +162,7 @@ function process_info(interp::AbstractInterpreter, @nospecialize(info::CCCallInf
         matches = info.results.matches
         return mapany(matches) do match::Core.MethodMatch
             mi = specialize_method(match)
-            effects = get_effects(interp, mi, false)
+            effects = get_effects(interp, mi, optimize)
             mici = MICallInfo(mi, rt, effects)
             return is_cached(mi) ? mici : UncachedCallInfo(mici)
         end


### PR DESCRIPTION
Without this, a custom interpreter that has better effects analysis after optimization is unable to surface its effects information to Cthulhu.