### PR TITLE
Add option to jump to source automatically

### DIFF
--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -125,7 +125,7 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
     iswarn::Bool=false, hide_type_stable::Bool=false, optimize::Bool=true,
     pc2remarks::Union{Nothing,PC2Remarks}=nothing, pc2effects::Union{Nothing,PC2Effects}=nothing,
     inline_cost::Bool=false, type_annotations::Bool=true, annotate_source::Bool=false,
-    inlay_types_vscode::Bool=false, diagnostics_vscode::Bool=false,
+    inlay_types_vscode::Bool=false, diagnostics_vscode::Bool=false, jump_always::Bool=false,
     interp::AbstractInterpreter=CthulhuInterpreter())
 
     debuginfo = IRShow.debuginfo(debuginfo)
@@ -157,7 +157,7 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
             end
   
             vscode_io = IOContext(
-                lambda_io, 
+                jump_always && inlay_types_vscode ? devnull : lambda_io,
                 :inlay_hints => inlay_types_vscode ? Dict{String,Vector{TypedSyntax.InlayHint}}() : nothing , 
                 :diagnostics => diagnostics_vscode ? TypedSyntax.Diagnostic[] : nothing
             )
@@ -185,7 +185,7 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
             TypedSyntax.display_diagnostics_vscode(callsite_diagnostics)
             TypedSyntax.display_inlay_hints_vscode(vscode_io)
  
-            println(lambda_io)
+            (jump_always && inlay_types_vscode) || println(lambda_io)
             istruncated && @info "This method only fills in default arguments; descend into the body method to see the full source."
             return nothing
         end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -38,6 +38,7 @@ function save_config!(config::CthulhuConfig=CONFIG)
         "annotate_source" => config.annotate_source,
         "inlay_types_vscode" => config.inlay_types_vscode,
         "diagnostics_vscode" => config.diagnostics_vscode,
+        "jump_always" => config.jump_always,
     )
 end
 
@@ -57,4 +58,5 @@ function read_config!(config::CthulhuConfig)
     config.annotate_source = @load_preference("annotate_source", config.annotate_source)
     config.inlay_types_vscode = @load_preference("inlay_types_vscode", config.inlay_types_vscode)
     config.diagnostics_vscode = @load_preference("diagnostics_vscode", config.diagnostics_vscode)
+    config.jump_always = @load_preference("always_edit", config.jump_always)
 end

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -92,8 +92,8 @@ function stringify(@nospecialize(f), context::IOContext)
 end
 
 const debugcolors = (:nothing, :light_black, :yellow)
-function usage(@nospecialize(view_cmd), annotate_source, optimize, iswarn, hide_type_stable, debuginfo, remarks, with_effects, inline_cost, type_annotations, highlight, inlay_types_vscode, diagnostics_vscode,
-    custom_toggles::Vector{CustomToggle})
+function usage(@nospecialize(view_cmd), annotate_source, optimize, iswarn, hide_type_stable, debuginfo, remarks, with_effects, inline_cost, type_annotations, highlight, 
+    inlay_types_vscode, diagnostics_vscode, jump_always, custom_toggles::Vector{CustomToggle})
     colorize(use_color::Bool, c::Char) = stringify() do io
         use_color ? printstyled(io, c; color=:cyan) : print(io, c)
     end
@@ -106,7 +106,8 @@ function usage(@nospecialize(view_cmd), annotate_source, optimize, iswarn, hide_
         colorize(iswarn, 'w'), "]arn, [",
         colorize(hide_type_stable, 'h'), "]ide type-stable statements, [",
         colorize(type_annotations, 't'), "]ype annotations, [",
-        colorize(highlight, 's'), "]yntax highlight for Source/LLVM/Native")
+        colorize(highlight, 's'), "]yntax highlight for Source/LLVM/Native, [",
+        colorize(jump_always, 'j'), "]ump to source always"),
     if TypedSyntax.inlay_hints_available_vscode()
         print(ioctx, ", [",
         colorize(inlay_types_vscode, 'v'), "]scode: inlay types")
@@ -169,7 +170,8 @@ const TOGGLES = Dict(
     UInt32('R') => :revise,
     UInt32('E') => :edit,
     UInt32('v') => :inlay_types_vscode,
-    UInt32('V') => :diagnostics_vscode
+    UInt32('V') => :diagnostics_vscode,
+    UInt32('j') => :jump_always
 )
 
 function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)


### PR DESCRIPTION
This rebases and fixes #336 and for VSCode preserves focus on terminal.
This also hides the annotated source code print out in the REPL if we jump to the annotated source code.