### PR TITLE
TypedSyntax.jl: drop old version support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,17 +43,11 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - name: dev TypedSyntax
-        shell: julia --color=yes --project=. {0}    # this is necessary for the next command to work on Windows
-        run: 'using Pkg; Pkg.develop(path=joinpath(pwd(), "TypedSyntax"))'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
           check_bounds: 'auto'
           coverage: 'false'
-      - name: TypedSyntax     # run the tests of TypedSyntax (a subdir package)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: julia --project=TypedSyntax -e 'using Pkg; Pkg.test(coverage=true)'
       # - name: Coverage off  # `empty_func` test doesn't work as intended with `coverage=true`
       #   if: ${{ matrix.os == 'ubuntu-latest' }}
       #   run: julia --project -e 'using Pkg; Pkg.test("Cthulhu"; coverage=false)'

--- a/.github/workflows/TypedSyntaxCI.yml
+++ b/.github/workflows/TypedSyntaxCI.yml
@@ -13,7 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'    # test LTS versions that are not supported by Cthulhu
+          - '1'
+          - '1.10.0'
+          - '1.11-nightly'
+          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -527,11 +527,9 @@ include("test_module.jl")
     @test node.typ === Type{Float64}
 
     # UnionAll in signature (issue #409)
-    @static if VERSION ≥ v"1.9-"
-        tsn = TypedSyntaxNode(Core.kwcall, (NamedTuple, typeof(issorted), Vector{Int}))
-        sig, body = children(tsn)
-        @test has_name_typ(child(sig, 2), :itr, Vector{Int})
-    end
+    tsn = TypedSyntaxNode(Core.kwcall, (NamedTuple, typeof(issorted), Vector{Int}))
+    sig, body = children(tsn)
+    @test has_name_typ(child(sig, 2), :itr, Vector{Int})
 
     # Empty `return` (issue #458)
     tsn = TypedSyntaxNode(TSN.f458, ())


### PR DESCRIPTION
Given that Cthulhu is the only user of TypedSyntax currently, and considering the newer versions of Cthulhu no longer supports older Julia versions like 1.6, I believe there isn't much merit in maintaining support for older Julia versions within TypedSyntax. We anticipate the need for fixes to TypedSyntax's reflection capabilities, like #547, however, continuing to provide support for these features across older versions proves to be a significant hassle. Therefore, I'm inclined to match TypedSyntax.jl's supported Julia version with that of Cthulhu.

Additionally, we've found that if Cthulhu's tests fail, TypedSyntax.jl's tests don't get executed, leading to unnoticed regressions in the latter. So I've opted to separate and individually run the tests for both Cthulhu and TypedSyntax.