### PR TITLE
Adjust to `OptimizationResult` changes

### DIFF
--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -124,7 +124,11 @@ end
 
 function create_cthulhu_source(@nospecialize(opt), effects::Effects)
     isa(opt, OptimizationState) || return opt
-    @static if VERSION ≥ v"1.11-"
+    @static if VERSION ≥ v"1.13-"
+        result = opt.result::CC.OptimizationResult
+        result.simplified || CC.simplify_ir!(result)
+        ir = CC.compact!(copy(result.ir))
+    elseif VERSION ≥ v"1.11-"
         # get the (theoretically) same effect as the jl_compress_ir -> jl_uncompress_ir -> inflate_ir round-trip
         ir = CC.compact!(CC.cfg_simplify!(CC.copy(opt.ir::IRCode)))
     else


### PR DESCRIPTION
`IRCode` now has a `.result::OptimizationResult` field, instead of a `.ir::IRCode` field.

Fixes #625.