### PR TITLE
Remove outdated version checks

### DIFF
--- a/.github/workflows/TypedSyntaxCI.yml
+++ b/.github/workflows/TypedSyntaxCI.yml
@@ -13,9 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
-          - '1.10.0'
-          - '1.11-nightly'
+          # - '1'
+          # - '1.12.0'
+          - '1.12-nightly'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -10,7 +10,7 @@ JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 [compat]
 CodeTracking = "1.3"
 JuliaSyntax = "0.4"
-julia = "1.10.0"
+julia = "1.12"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -670,14 +670,6 @@ include("test_module.jl")
     tsn = TypedSyntaxNode(+, (Int, Int)) # need a node, not important what it is
     @test_nowarn TypedSyntax.type_annotation_mode(tsn, Union{}; type_annotations=true, hide_type_stable=false)
 
-    # issue 492
-    @static if isdefined(Base, :_tuple_unique_fieldtypes)
-    tsn = TypedSyntaxNode(Base._tuple_unique_fieldtypes, (Any,))
-    @test_nowarn str = sprint(tsn; context=:color=>false) do io, obj
-        printstyled(io, obj; hide_type_stable=false)
-    end
-    end
-
     # issue 493
     tsn = TypedSyntaxNode(TSN.f493, ())
     @test_nowarn str = sprint(tsn; context=:color=>false) do io, obj

--- a/ext/CthulhuCompilerExt.jl
+++ b/ext/CthulhuCompilerExt.jl
@@ -1,15 +1,13 @@
 module CthulhuCompilerExt
 
-@static if VERSION ≥ v"1.12.0-DEV.1581"
-    using Compiler: Compiler as CC
-    using Compiler.IRShow: IRShow
-    using Cthulhu: Cthulhu
+using Compiler: Compiler as CC
+using Compiler.IRShow: IRShow
+using Cthulhu: Cthulhu
 
-    function __init__()
-        Cthulhu.CTHULHU_MODULE[] = @__MODULE__
-    end
-
-    include("../src/CthulhuBase.jl")
+function __init__()
+    Cthulhu.CTHULHU_MODULE[] = @__MODULE__
 end
+
+include("../src/CthulhuBase.jl")
 
 end

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -3,13 +3,8 @@ module Cthulhu
 export @descend, @descend_code_typed, @descend_code_warntype,
     descend, descend_code_typed, descend_code_warntype, ascend
 
-@static if VERSION ≥ v"1.12.0-DEV.1581"
-    const CC = Base.Compiler
-    const IRShow = Base.IRShow
-else
-    const CC = Core.Compiler
-    const IRShow = Base.IRShow
-end
+const CC = Base.Compiler
+const IRShow = Base.IRShow
 
 const CTHULHU_MODULE = Ref{Module}(@__MODULE__)
 
@@ -202,10 +197,8 @@ using PrecompileTools
 
         @compile_workload descend(gcd, (Int, Int); terminal=term)
 
-        # @static if VERSION ≥ v"1.12.0-DEV.1581"
-        #     using Compiler
-        #     @compile_workload descend(gcd, (Int, Int); terminal=term)
-        # end
+    #     using Compiler
+    #     @compile_workload descend(gcd, (Int, Int); terminal=term)
 
         # declare we are done with streams
         close(input.in)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -197,8 +197,8 @@ using PrecompileTools
 
         @compile_workload descend(gcd, (Int, Int); terminal=term)
 
-    #     using Compiler
-    #     @compile_workload descend(gcd, (Int, Int); terminal=term)
+        # using Compiler
+        # @compile_workload descend(gcd, (Int, Int); terminal=term)
 
         # declare we are done with streams
         close(input.in)

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -46,45 +46,27 @@ end
 Base.show(io::IO, interp::CthulhuInterpreter) = print(io, typeof(interp), "(...)")
 
 CC.InferenceParams(interp::CthulhuInterpreter) = InferenceParams(interp.native)
-@static if VERSION ≥ v"1.11.0-DEV.851"
 CC.OptimizationParams(interp::CthulhuInterpreter) =
     OptimizationParams(OptimizationParams(interp.native); preserve_local_sources=true)
-else
-CC.OptimizationParams(interp::CthulhuInterpreter) = OptimizationParams(interp.native)
-end
-#=CC.=#get_inference_world(interp::CthulhuInterpreter) = get_inference_world(interp.native)
+CC.get_inference_world(interp::CthulhuInterpreter) = get_inference_world(interp.native)
 CC.get_inference_cache(interp::CthulhuInterpreter) = CC.get_inference_cache(interp.native)
 
 CC.may_optimize(::CthulhuInterpreter) = true
 CC.may_compress(::CthulhuInterpreter) = false
 CC.may_discard_trees(::CthulhuInterpreter) = false
-@static if isdefined(CC, :verbose_stmt_info)
-CC.verbose_stmt_info(::CthulhuInterpreter) = true
-end
-
 CC.method_table(interp::CthulhuInterpreter) = CC.method_table(interp.native)
 
-@static if VERSION ≥ v"1.11.0-DEV.1552"
 # Since the cache for `CthulhuInterpreter` is volatile and does not involve with the
 # internal code cache, technically, there's no requirement to supply `cache_owner` as an
 # identifier for the internal code cache. However, the definition of `cache_owner` is
 # necessary for utilizing the default `CodeInstance` constructor, define the overload here.
 CC.cache_owner(interp::CthulhuInterpreter) = interp.cache_token
-end
 
 function get_inference_key(state::InferenceState)
-    @static if VERSION ≥ v"1.12-"
-        result = state.result
-        if CC.is_constproped(state)
-            return result # TODO result.ci_as_edge?
-        elseif isdefined(result, :ci)
-            return result.ci
-        else
-            return nothing
-        end
-    else
-        return CC.any(state.result.overridden_by_const) ? state.result : state.linfo
-    end
+    result = state.result
+    CC.is_constproped(state) && return result # TODO result.ci_as_edge?
+    isdefined(result, :ci) && return result.ci
+    return nothing
 end
 
 function CC.add_remark!(interp::CthulhuInterpreter, sv::InferenceState, msg)
@@ -102,7 +84,6 @@ function CC.merge_effects!(interp::CthulhuInterpreter, sv::InferenceState, effec
     @invoke CC.merge_effects!(interp::AbstractInterpreter, sv::InferenceState, effects::Effects)
 end
 
-@static if VERSION ≥ v"1.11.0-DEV.1127"
 function CC.update_exc_bestguess!(interp::CthulhuInterpreter, @nospecialize(exct),
                                   frame::InferenceState)
     key = get_inference_key(frame)
@@ -114,11 +95,10 @@ function CC.update_exc_bestguess!(interp::CthulhuInterpreter, @nospecialize(exct
     return @invoke CC.update_exc_bestguess!(interp::AbstractInterpreter, exct::Any,
                                             frame::InferenceState)
 end
-end
 
 function InferredSource(state::InferenceState)
     unoptsrc = copy(state.src)
-    exct = @static VERSION ≥ v"1.11.0-DEV.207" ? state.result.exc_result : nothing
+    exct = state.result.exc_result
     return InferredSource(
         unoptsrc,
         copy(state.stmt_info),
@@ -127,7 +107,6 @@ function InferredSource(state::InferenceState)
         exct)
 end
 
-@static if VERSION ≥ v"1.12-"
 function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter, cycleid::Int)
     res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter, cycleid::Int)
     key = get_inference_key(state)
@@ -137,29 +116,15 @@ function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::
     return res
 end
 
-else
-function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter)
-    res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter)
-    key = get_inference_key(state)
-    if key !== nothing
-        interp.unopt[key] = InferredSource(state)
-    end
-    return res
-end
-end
-
 function create_cthulhu_source(@nospecialize(opt), effects::Effects)
     isa(opt, OptimizationState) || return opt
     @static if VERSION ≥ v"1.13-"
         result = opt.result::CC.OptimizationResult
         result.simplified || CC.simplify_ir!(result)
         ir = CC.compact!(copy(result.ir))
-    elseif VERSION ≥ v"1.11-"
+    else
         # get the (theoretically) same effect as the jl_compress_ir -> jl_uncompress_ir -> inflate_ir round-trip
         ir = CC.compact!(CC.cfg_simplify!(CC.copy(opt.ir::IRCode)))
-    else
-        # TODO do the round-trip here?
-        ir = CC.copy(opt.ir::IRCode)
     end
     return OptimizedSource(ir, opt.src, opt.src.inlineable, effects)
 end
@@ -168,58 +133,12 @@ function set_cthulhu_source!(result::InferenceResult)
     result.src = create_cthulhu_source(result.src, result.ipo_effects)
 end
 
-@static if VERSION ≥ v"1.12.0-DEV.1823"
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter, cycleid::Int) = cthulhu_finish(CC.finishinfer!, state, interp, cycleid)
-@static if VERSION ≥ v"1.12-"
 function CC.finish!(interp::CthulhuInterpreter, caller::InferenceState, validation_world::UInt, time_before::UInt64)
     set_cthulhu_source!(caller.result)
     return @invoke CC.finish!(interp::AbstractInterpreter, caller::InferenceState, validation_world::UInt, time_before::UInt64)
 end
-else
-function CC.finish!(interp::CthulhuInterpreter, caller::InferenceState)
-    set_cthulhu_source!(caller.result)
-    return @invoke CC.finish!(interp::AbstractInterpreter, caller::InferenceState)
-end
-end
 
-elseif VERSION ≥ v"1.12.0-DEV.734"
-CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter) = cthulhu_finish(CC.finishinfer!, state, interp)
-function CC.finish!(interp::CthulhuInterpreter, caller::InferenceState;
-                    can_discard_trees::Bool=false)
-    set_cthulhu_source!(caller.result)
-    return @invoke CC.finish!(interp::AbstractInterpreter, caller::InferenceState;
-                              can_discard_trees)
-end
-
-elseif VERSION ≥ v"1.11.0-DEV.737"
-CC.finish(state::InferenceState, interp::CthulhuInterpreter) = cthulhu_finish(CC.finish, state, interp)
-function CC.finish!(interp::CthulhuInterpreter, caller::InferenceState)
-    result = caller.result
-    opt = result.src
-    set_cthulhu_source!(result)
-    if opt isa CC.OptimizationState
-        CC.ir_to_codeinf!(opt)
-    end
-    return nothing
-end
-function CC.transform_result_for_cache(::CthulhuInterpreter, ::MethodInstance, ::WorldRange,
-                                       result::InferenceResult)
-    return result.src
-end
-
-else # VERSION < v"1.11.0-DEV.737"
-CC.finish(state::InferenceState, interp::CthulhuInterpreter) = cthulhu_finish(CC.finish, state, interp)
-function CC.transform_result_for_cache(::CthulhuInterpreter, ::MethodInstance, ::WorldRange,
-                                       result::InferenceResult)
-    return create_cthulhu_source(result.src, result.ipo_effects)
-end
-function CC.finish!(interp::CthulhuInterpreter, caller::InferenceResult)
-    caller.src = create_cthulhu_source(caller.src, caller.ipo_effects)
-end
-
-end # @static if
-
-@static if VERSION ≥ v"1.12.0-DEV.45"
 function CC.src_inlining_policy(interp::CthulhuInterpreter,
     @nospecialize(src), @nospecialize(info::CCCallInfo), stmt_flag::UInt32)
     if isa(src, OptimizedSource)
@@ -238,41 +157,6 @@ CC.retrieve_ir_for_inlining(cached_result::CodeInstance, src::OptimizedSource) =
     CC.retrieve_ir_for_inlining(cached_result.def, src.ir::IRCode, true)
 CC.retrieve_ir_for_inlining(mi::MethodInstance, src::OptimizedSource, preserve_local_sources::Bool) =
     CC.retrieve_ir_for_inlining(mi, src.ir, preserve_local_sources)
-elseif VERSION ≥ v"1.11.0-DEV.879"
-function CC.inlining_policy(interp::CthulhuInterpreter,
-    @nospecialize(src), @nospecialize(info::CCCallInfo), stmt_flag::UInt32)
-    if isa(src, OptimizedSource)
-        if CC.is_stmt_inline(stmt_flag) || src.isinlineable
-            return src.ir
-        end
-    else
-        @assert src isa CC.IRCode || src === nothing "invalid Cthulhu code cache"
-        # the default inlining policy may try additional effor to find the source in a local cache
-        return @invoke CC.inlining_policy(interp::AbstractInterpreter,
-            src::Any, info::CCCallInfo, stmt_flag::UInt32)
-    end
-    return nothing
-end
-else
-function CC.inlining_policy(interp::CthulhuInterpreter,
-    @nospecialize(src), @nospecialize(info::CCCallInfo),
-    stmt_flag::(@static VERSION ≥ v"1.11.0-DEV.377" ? UInt32 : UInt8),
-    mi::MethodInstance, argtypes::Vector{Any})
-    if isa(src, OptimizedSource)
-        if CC.is_stmt_inline(stmt_flag) || src.isinlineable
-            return src.ir
-        end
-    else
-        @assert src isa CC.SemiConcreteResult || src === nothing "invalid Cthulhu code cache"
-        # the default inlining policy may try additional effor to find the source in a local cache
-        return @invoke CC.inlining_policy(interp::AbstractInterpreter,
-            src::Any, info::CCCallInfo,
-            stmt_flag::(@static VERSION ≥ v"1.11.0-DEV.377" ? UInt32 : UInt8),
-            mi::MethodInstance, argtypes::Vector{Any})
-    end
-    return nothing
-end
-end
 
 function CC.IRInterpretationState(interp::CthulhuInterpreter,
     code::CodeInstance, mi::MethodInstance, argtypes::Vector{Any}, world::UInt)
@@ -281,16 +165,8 @@ function CC.IRInterpretationState(interp::CthulhuInterpreter,
     inferred = inferred::OptimizedSource
     ir = CC.copy(inferred.ir)
     src = inferred.src
-    @static if isdefined(CC, :SpecInfo)
-        spec_info = CC.SpecInfo(src)
-    else
-        spec_info = CC.MethodInfo(src)
-    end
-    if isdefined(Base, :__has_internal_change) && Base.__has_internal_change(v"1.12-", :codeinfonargs)
-        argtypes = CC.va_process_argtypes(CC.optimizer_lattice(interp), argtypes, src.nargs, src.isva)
-    elseif VERSION >= v"1.12.0-DEV.341"
-        argtypes = CC.va_process_argtypes(CC.optimizer_lattice(interp), argtypes, mi)
-    end
+    spec_info = CC.SpecInfo(src)
+    argtypes = CC.va_process_argtypes(CC.optimizer_lattice(interp), argtypes, src.nargs, src.isva)
     return CC.IRInterpretationState(interp, spec_info, ir, mi, argtypes, world,
                                     code.min_world, code.max_world)
 end

--- a/test/irutils.jl
+++ b/test/irutils.jl
@@ -35,11 +35,7 @@ end
 # check if `x` is a statically-resolved call of a function whose name is `sym`
 isinvoke(y) = @nospecialize(x) -> isinvoke(y, x)
 isinvoke(sym::Symbol, @nospecialize(x)) = isinvoke(mi->mi.def.name===sym, x)
-@static if VERSION ≥ v"1.12.0-DEV.1667"
 isinvoke(pred::Function, @nospecialize(x)) = isexpr(x, :invoke) && pred(x.args[1]::CodeInstance)
-else
-isinvoke(pred::Function, @nospecialize(x)) = isexpr(x, :invoke) && pred(x.args[1]::MethodInstance)
-end
 
 function fully_eliminated(@nospecialize args...; retval=(@__FILE__), kwargs...)
     code = code_typed1(args...; kwargs...).code

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -3,9 +3,7 @@ if isdefined(parentmodule(@__MODULE__), :VSCodeServer)
     using ..VSCodeServer
 end
 
-# @static if VERSION ≥ v"1.12.0-DEV.1581"
 # InteractiveUtils.@activate Compiler # use the Compiler.jl stdlib for the Base reflections too
-# end
 
 function cthulhu_info(@nospecialize(f), @nospecialize(tt=());
                       optimize=true, interp=Cthulhu.CC.NativeInterpreter())

--- a/test/test_AbstractInterpreter.jl
+++ b/test/test_AbstractInterpreter.jl
@@ -18,7 +18,6 @@ Keep in mind that ephemeral cache lacks support for invalidation and doesn't per
 sessions. However it is an usual Julia object of the type `code_cache::IdDict{MethodInstance,CodeInstance}`,
 making it easier for debugging and inspecting the compiler behavior.
 """
-@static if VERSION ≥ v"1.11.0-DEV.1552"
 macro newinterp(InterpName, ephemeral_cache::Bool=false)
     cache_token = QuoteNode(gensym(string(InterpName, "CacheToken")))
     InterpCacheName = esc(Symbol(string(InterpName, "Cache")))
@@ -66,49 +65,6 @@ macro newinterp(InterpName, ephemeral_cache::Bool=false)
         end)
     end
 end
-else
-macro newinterp(InterpName)
-    InterpCacheName = esc(Symbol(string(InterpName, "Cache")))
-    InterpName = esc(InterpName)
-    C = Core
-    CC = Core.Compiler
-    quote
-        struct $InterpCacheName
-            dict::IdDict{$C.MethodInstance,$C.CodeInstance}
-        end
-        $InterpCacheName() = $InterpCacheName(IdDict{$C.MethodInstance,$C.CodeInstance}())
-        struct $InterpName <: $CC.AbstractInterpreter
-            meta # additional information
-            world::UInt
-            inf_params::$CC.InferenceParams
-            opt_params::$CC.OptimizationParams
-            inf_cache::Vector{$CC.InferenceResult}
-            code_cache::$InterpCacheName
-            function $InterpName(meta = nothing;
-                                 world::UInt = Base.get_world_counter(),
-                                 inf_params::$CC.InferenceParams = $CC.InferenceParams(),
-                                 opt_params::$CC.OptimizationParams = $CC.OptimizationParams(),
-                                 inf_cache::Vector{$CC.InferenceResult} = $CC.InferenceResult[],
-                                 code_cache::$InterpCacheName = $InterpCacheName())
-                return new(meta, world, inf_params, opt_params, inf_cache, code_cache)
-            end
-        end
-        $CC.InferenceParams(interp::$InterpName) = interp.inf_params
-        $CC.OptimizationParams(interp::$InterpName) = interp.opt_params
-        @static if VERSION ≥ v"1.11.0-DEV.1498"
-        CC.get_inference_world(interp::$InterpName) = interp.world
-        else
-        CC.get_world_counter(interp::$InterpName) = interp.world
-        end
-        $CC.get_inference_cache(interp::$InterpName) = interp.inf_cache
-        $CC.code_cache(interp::$InterpName) = $CC.WorldView(interp.code_cache, $CC.WorldRange(interp.world))
-        $CC.get(wvc::$CC.WorldView{$InterpCacheName}, mi::$C.MethodInstance, default) = get(wvc.cache.dict, mi, default)
-        $CC.getindex(wvc::$CC.WorldView{$InterpCacheName}, mi::$C.MethodInstance) = getindex(wvc.cache.dict, mi)
-        $CC.haskey(wvc::$CC.WorldView{$InterpCacheName}, mi::$C.MethodInstance) = haskey(wvc.cache.dict, mi)
-        $CC.setindex!(wvc::$CC.WorldView{$InterpCacheName}, ci::$C.CodeInstance, mi::$C.MethodInstance) = setindex!(wvc.cache.dict, ci, mi)
-    end
-end
-end # if VERSION ≥ v"1.11.0-DEV.1552"
 
 const CC = Cthulhu.CC
 

--- a/test/test_codeview.jl
+++ b/test/test_codeview.jl
@@ -22,12 +22,8 @@ Revise.track(TestCodeViewSandbox, normpath(@__DIR__, "TestCodeViewSandbox.jl"))
                 config = Cthulhu.CONFIG
 
                 io = IOBuffer()
-                @static if VERSION < v"1.12.0-DEV.669"
-                    codeview(io, mi, optimize, debuginfo, Cthulhu.get_inference_world(interp), config)
-                else
-                    src = Cthulhu.CC.typeinf_code(interp, mi, true)
-                    codeview(io, mi, src, optimize, debuginfo, Cthulhu.get_inference_world(interp), config)
-                end
+                src = Cthulhu.CC.typeinf_code(interp, mi, true)
+                codeview(io, mi, src, optimize, debuginfo, Cthulhu.get_inference_world(interp), config)
                 @test !isempty(String(take!(io))) # just check it works
             end
         end


### PR DESCRIPTION
As we are removing support for Julia versions < 1.12 starting from the 2.17 release, we can remove all version checks that may be optimized away assuming `VERSION >= v"1.12-"`.
