### PR TITLE
Refactor: extend cache transforms to store `OptimizedSource`

### DIFF
--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -132,6 +132,9 @@ function CC.transform_result_for_local_cache(interp::CthulhuInterpreter, result:
 end
 
 function CC.transform_result_for_cache(interp::CthulhuInterpreter, result::InferenceResult, edges::Core.SimpleVector)
+    if isa(result.src, CodeInfo)
+        result.src.edges = edges
+    end
     result.src = CC.transform_result_for_local_cache(interp, result)
 end
 

--- a/test/cthulhu.jl
+++ b/test/cthulhu.jl
@@ -1,0 +1,3 @@
+using Cthulhu: CTHULHU_MODULE
+const Cthulhu = CTHULHU_MODULE[]
+const CC = Cthulhu.CC

--- a/test/generate_irshow.jl
+++ b/test/generate_irshow.jl
@@ -1,7 +1,5 @@
 module generate_irshow
 
-using Cthulhu
-
 include("setup.jl")
 include("irshowutils.jl")
 include("IRShowSandbox.jl")

--- a/test/irutils.jl
+++ b/test/irutils.jl
@@ -1,5 +1,4 @@
 using Core.IR
-using Cthulhu: Cthulhu
 using Base.Meta: isexpr
 using InteractiveUtils: gen_call_with_extracted_types_and_kwargs
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,12 +1,14 @@
-using Test, Cthulhu, InteractiveUtils
+using Test, InteractiveUtils
 if isdefined(parentmodule(@__MODULE__), :VSCodeServer)
     using ..VSCodeServer
 end
 
 # InteractiveUtils.@activate Compiler # use the Compiler.jl stdlib for the Base reflections too
 
+include("cthulhu.jl")
+
 function cthulhu_info(@nospecialize(f), @nospecialize(tt=());
-                      optimize=true, interp=Cthulhu.CC.NativeInterpreter())
+                      optimize=true, interp=CC.NativeInterpreter())
     (interp, codeinst) = Cthulhu.mkinterp(f, tt; interp)
     (; src, rt, exct, infos, slottypes, effects) =
         Cthulhu.lookup(interp, codeinst, optimize; allow_no_src=true)

--- a/test/test_AbstractInterpreter.jl
+++ b/test/test_AbstractInterpreter.jl
@@ -1,9 +1,11 @@
 module test_AbstractInterpreter
 
-using Test, Cthulhu
+using Test
 if isdefined(parentmodule(@__MODULE__), :VSCodeServer)
     using ..VSCodeServer
 end
+
+include("cthulhu.jl")
 
 @doc """
     @newinterp NewInterpreter [ephemeral_cache::Bool=false]
@@ -65,8 +67,6 @@ macro newinterp(InterpName, ephemeral_cache::Bool=false)
         end)
     end
 end
-
-const CC = Cthulhu.CC
 
 # `OverlayMethodTable`
 # --------------------

--- a/test/test_Cthulhu.jl
+++ b/test/test_Cthulhu.jl
@@ -1,8 +1,7 @@
 module test_Cthulhu
 
-using Test, Cthulhu, StaticArrays, Random
+using Test, StaticArrays, Random
 using Core: Const
-const CC = Cthulhu.CTHULHU_MODULE[].CC
 
 include("setup.jl")
 include("irutils.jl")

--- a/test/test_Cthulhu.jl
+++ b/test/test_Cthulhu.jl
@@ -773,14 +773,13 @@ end
 @testset "ascend interface" begin
     m = Module()
     @eval m begin
-        using Cthulhu
         struct FunnyMI end
         struct HasName
             name::Symbol
         end
-        Cthulhu.method(::FunnyMI) = HasName(:funny)
+        $Cthulhu.method(::FunnyMI) = HasName(:funny)
         funny(c::Char) = "haha"
-        Cthulhu.specTypes(::FunnyMI) = Tuple{typeof(funny),Char}
+        $Cthulhu.specTypes(::FunnyMI) = Tuple{typeof(funny),Char}
     end
 
     io = IOBuffer()

--- a/test/test_codeview.jl
+++ b/test/test_codeview.jl
@@ -1,6 +1,6 @@
 module test_codeview
 
-using Cthulhu, Test, Revise
+using Test, Revise
 
 include("setup.jl")
 

--- a/test/test_codeview_vscode.jl
+++ b/test/test_codeview_vscode.jl
@@ -1,8 +1,9 @@
 module test_codeview_vscode
 
-using Cthulhu, Test, Revise, REPL, ..VSCodeServer, TypedSyntax
+using Test, Revise, REPL, ..VSCodeServer, TypedSyntax
 import TypedSyntax: InlayHintKinds
 
+include("cthulhu.jl")
 include("test_vscode_example_functions.jl")
 
 @testset "VSCode descend test" begin

--- a/test/test_irshow.jl
+++ b/test/test_irshow.jl
@@ -1,6 +1,6 @@
 module tests_irshow
 
-using Cthulhu, Test, DeepDiffs
+using Test, DeepDiffs
 
 include("setup.jl")
 include("irshowutils.jl")

--- a/test/test_terminal.jl
+++ b/test/test_terminal.jl
@@ -1,9 +1,11 @@
 module test_terminal
 
-using Test, REPL, Cthulhu, Revise
+using Test, REPL, Revise
 if isdefined(parentmodule(@__MODULE__), :VSCodeServer)
     using ..VSCodeServer
 end
+
+include("cthulhu.jl")
 
 if !isdefined(@__MODULE__, :fake_terminal)
     @eval (@__MODULE__) begin


### PR DESCRIPTION
It seems that using the `transform_result_for_cache` and `transform_result_for_local_cache` mechanisms, we don't need to override `finish!` anymore.

Therefore, we now have:
- `CC.finishinfer!` to store inferred, unoptimized sources (`InferredSource`)
- `CC.transform_result_for_cache` and `CC.transform_result_for_local_cache` to store inferred, optimized sources (`OptimizedSource`)