### PR TITLE
Adjust to `finishinfer!` signature change

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
-version = "2.17.2"
+version = "2.17.3"
 
 [compat]
 CodeTracking = "0.5, 1"

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -126,7 +126,7 @@ function set_cthulhu_source!(result::InferenceResult)
     result.src = create_cthulhu_source(result, result.ipo_effects)
 end
 
-if VERSION ≥ v"1.13-"
+@static if VERSION ≥ v"1.13-"
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter, cycleid::Int, opt_cache::IdDict{MethodInstance, CodeInstance}) = cthulhu_finish(CC.finishinfer!, state, interp, cycleid, opt_cache)
 function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter, cycleid::Int, opt_cache::IdDict{MethodInstance, CodeInstance})
     res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter, cycleid::Int, opt_cache::IdDict{MethodInstance, CodeInstance})

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -107,15 +107,6 @@ function InferredSource(state::InferenceState)
         exct)
 end
 
-function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter, cycleid::Int)
-    res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter, cycleid::Int)
-    key = get_inference_key(state)
-    if key !== nothing
-        interp.unopt[key] = InferredSource(state)
-    end
-    return res
-end
-
 function create_cthulhu_source(result::InferenceResult, effects::Effects)
     isa(result.src, OptimizationState) || return result.src
     opt = result.src
@@ -135,7 +126,28 @@ function set_cthulhu_source!(result::InferenceResult)
     result.src = create_cthulhu_source(result, result.ipo_effects)
 end
 
+if VERSION ≥ v"1.13-"
+CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter, cycleid::Int, opt_cache::IdDict{MethodInstance, CodeInstance}) = cthulhu_finish(CC.finishinfer!, state, interp, cycleid, opt_cache)
+function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter, cycleid::Int, opt_cache::IdDict{MethodInstance, CodeInstance})
+    res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter, cycleid::Int, opt_cache::IdDict{MethodInstance, CodeInstance})
+    key = get_inference_key(state)
+    if key !== nothing
+        interp.unopt[key] = InferredSource(state)
+    end
+    return res
+end
+else
+function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter, cycleid::Int)
+    res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter, cycleid::Int)
+    key = get_inference_key(state)
+    if key !== nothing
+        interp.unopt[key] = InferredSource(state)
+    end
+    return res
+end
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter, cycleid::Int) = cthulhu_finish(CC.finishinfer!, state, interp, cycleid)
+end
+
 function CC.finish!(interp::CthulhuInterpreter, caller::InferenceState, validation_world::UInt, time_before::UInt64)
     set_cthulhu_source!(caller.result)
     return @invoke CC.finish!(interp::AbstractInterpreter, caller::InferenceState, validation_world::UInt, time_before::UInt64)


### PR DESCRIPTION
Fixes a breakage introduced by a signature change in https://github.com/JuliaLang/julia/pull/58343.