### PR TITLE
Do not rely on `Base.active_repl`

### DIFF
--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -142,7 +142,11 @@ function __descend_with_error_handling(args...; terminal=default_terminal(), kwa
     return nothing
 end
 
-default_terminal() = REPL.LineEdit.terminal(Base.active_repl)
+function default_terminal()
+    term_env = get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb")
+    term = REPL.Terminals.TTYTerminal(term_env, stdin, stdout, stderr)
+    return term
+end
 
 descend_impl(@nospecialize(args...); kwargs...) =
     _descend_with_error_handling(args...; iswarn=true, kwargs...)

--- a/test/test_terminal.jl
+++ b/test/test_terminal.jl
@@ -40,9 +40,7 @@ macro with_try_stderr(out, expr)
 end
 
 @testset "Terminal" begin
-    if isdefined(Base, :active_repl)
-        @test Cthulhu.default_terminal() isa REPL.Terminals.TTYTerminal
-    end
+    @test Cthulhu.default_terminal() isa REPL.Terminals.TTYTerminal
     colorize(use_color::Bool, c::Char) = Cthulhu.stringify() do io
         use_color ? printstyled(io, c; color=:cyan) : print(io, c)
     end


### PR DESCRIPTION
Relying on `Base.active_repl` introduced two failure modes:
- If `Cthulhu.REPL !== parentmodule(typeof(Base.active_repl))`, we error.
- If we launch in non-interactive mode, `Base.active_repl` is not defined and we error.

We used it only to retrieve a terminal, but as it turns out the setup is [extremely simple](https://github.com/JuliaLang/julia/blob/2c2114ceed8a538290fbb6413e314c28bfd5b4f3/base/client.jl#L472-L473) so it seems we can just do that ourselves. From what I understand, it hooks into `stdout`/`stdin`/`stderr`, but nothing requires interacting with `Base.active_repl`.

This should fix #450.

Reproducing the first failure mode (and ensuring it is now fixed) is a bit tricky, these conditions seem to work for me:
- Copy the REPL package from its stdlib location to somewhere else (e.g. `~/.julia/dev`).
- `dev` it within the Cthulhu project.
- Launch Julia with `julia --project --startup-file=no` then execute `using Cthulhu; @descend exp(4)`.
- This should error on `master` and pass on this PR.

The second failure mode can be reproduced with https://github.com/JuliaDebug/Cthulhu.jl/issues/450#issuecomment-2877185147.