### PR TITLE
Fix tests for nightly

### DIFF
--- a/src/backedges.jl
+++ b/src/backedges.jl
@@ -1,7 +1,7 @@
 # A lightly-modified version of the same function in Base
 # Highlights argument types with color specified by highlighter(typ)
 
-get_fname(@nospecialize(fT::DataType)) = @static VERSION ≥ v"1.13.0-DEV.647" ? fT.name.singletonname : fT.name.mt.name
+get_fname(@nospecialize(fT::DataType)) = fT.name.singletonname
 
 function show_tuple_as_call(@nospecialize(highlighter), io::IO, name::Symbol, @nospecialize(sig::Type), demangle=false #=, kwargs=nothing =#)
     if sig === Tuple

--- a/test/test_Cthulhu.jl
+++ b/test/test_Cthulhu.jl
@@ -22,6 +22,8 @@ end
 
 function empty_func(::Bool) end
 
+pure_concrete_eval() = exp((1, 1)[1])
+
 anykwargs(a; kwargs...) = println(a, " keyword args: ", kwargs...)
 hasdefaultargs(a, b=2) = a + b
 
@@ -47,9 +49,10 @@ end
     @test isempty(callsites)
 
     # handle pure
-    callsites = find_callsites_by_ftt(iterate, Tuple{SVector{3,Int}, Tuple{SOneTo{3}}}; optimize=false)
+    callsites = find_callsites_by_ftt(pure_concrete_eval; optimize=false)
     @test occursin("::Const((1, 1))", string(callsites[1]))
-    @test occursin(r"< (constprop|concrete eval) > getindex\(::.*Const.*,::.*Const\(1\)\)::.*Const\(1\)", string(callsites[2]))
+    @test occursin(r"< (constprop|concrete eval) > getindex\(::.*Const.*,::.*Const\(1\)\)::.*Const\(1\)", string(callsites[1]))
+
     callsites = @eval find_callsites_by_ftt(; optimize=false) do
         length($(QuoteNode(Core.svec(0,1,2))))
     end


### PR DESCRIPTION
Inferred code for one of the tests changed on nightly (it remains identical as before with `optimize=true`, I don't think it is necessary to report as a bug upstream). I replaced the function with a simpler one that should be less likely to break.