### PR TITLE
Bump [compat] for Julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,10 @@
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
-version = "2.16.5"
+version = "2.16.6"
 
 [compat]
-CodeTracking = "0.5, 1"
+CodeTracking = "0.5, 1, 2"
 Compiler = "0, 1"
 FoldingTrees = "1"
 InteractiveUtils = "1.9"

--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,14 +1,14 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.4.2"
+version = "1.4.3"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 
 [compat]
-CodeTracking = "1.3"
+CodeTracking = "1.3, 2"
 JuliaSyntax = "0.4"
 julia = "1.10.0"
 


### PR DESCRIPTION
This adds to a new "backporting" branch, `julia-1.10`, and prepares for
a new release compatible with CodeTracking v2.