### PR TITLE
Split `backedges.jl` from reincluded source files

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -11,6 +11,7 @@ const CTHULHU_MODULE = Ref{Module}(@__MODULE__)
 __init__() = read_config!(CONFIG)
 
 include("CthulhuBase.jl")
+include("backedges.jl")
 include("testing.jl")
 
 """

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -96,7 +96,6 @@ include("interface.jl")
 include("reflection.jl")
 include("ui.jl")
 include("codeview.jl")
-include("backedges.jl")
 
 """
     @interp
@@ -692,13 +691,11 @@ descend_code_typed_impl(b::Bookmark; kw...) =
 descend_code_warntype_impl(b::Bookmark; kw...) =
     _descend_with_error_handling(b.interp, b.ci.def; iswarn=true, kw...)
 
-FoldingTrees.writeoption(buf::IO, data::Data, charsused::Int) = FoldingTrees.writeoption(buf, data.callstr, charsused)
-
 function ascend_impl(
         term, mi; interp::AbstractInterpreter=NativeInterpreter(),
         pagesize::Int=10, dynamic::Bool=false, maxsize::Int=pagesize, kwargs...
     )
-    root = treelist(mi)
+    root = Cthulhu.treelist(mi)
     root === nothing && return
     menu = TreeMenu(root; pagesize, dynamic, maxsize)
     choice = menu.current
@@ -708,10 +705,10 @@ function ascend_impl(
         browsecodetyped = true
         if choice !== nothing
             node = menu.current
-            mi = instance(node.data.nd)
+            mi = Cthulhu.instance(node.data.nd)
             if !isroot(node)
                 # Help user find the sites calling the parent
-                miparent = instance(node.parent.data.nd)
+                miparent = Cthulhu.instance(node.parent.data.nd)
                 ulocs = find_caller_of(interp, miparent, mi; allow_unspecialized=true)
                 if !isempty(ulocs)
                     ulocs = [(k[1], maybe_fix_path(String(k[2])), k[3]) => v for (k, v) in ulocs]

--- a/src/backedges.jl
+++ b/src/backedges.jl
@@ -204,3 +204,5 @@ function treelist(exstk::Base.ExceptionStack)
     @error "exception stack contains $(length(exstk.stack)) exceptions, pick one with `ascend(err.stack[i].backtrace)`"
     return nothing
 end
+
+FoldingTrees.writeoption(buf::IO, data::Data, charsused::Int) = FoldingTrees.writeoption(buf, data.callstr, charsused)


### PR DESCRIPTION
This PR moves the `include("backedges.jl")` call from `CthulhuBase.jl` to `Cthulhu.jl`, so we only include it once and we don't reinclude it in the extension. `ascend` then qualifies its calls to the relevant functions, such as `Cthulhu.treelist` and `Cthulhu.instance`.

Solves https://github.com/JuliaDebug/Cthulhu.jl/pull/619#issuecomment-3242190458 for this part of the codebase.