### PR TITLE
Fix stack overflow in descend_code_typed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
-version = "2.17.7"
+version = "2.17.8"
 
 [compat]
 CodeTracking = "0.5, 1, 2"

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -143,7 +143,7 @@ julia> descend_code_typed() do
 ```
 """
 function descend_code_typed(@nospecialize(args...); kwargs...)
-    CTHULHU_MODULE[].descend_code_typed(args...; kwargs...)
+    CTHULHU_MODULE[].descend_code_typed_impl(args...; kwargs...)
 end
 
 """


### PR DESCRIPTION
Fixes a typo introduced in ac0a42893210ac032e4e09aa9bd9dc751e7a1b4b.