### PR TITLE
Remove use of outdated `isempty(children(...))` pattern

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
-version = "2.17.9"
+version = "2.17.10"
 
 [compat]
 CodeTracking = "0.5, 1, 2"

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -285,7 +285,7 @@ function descend_into_callsite!(io::IO, tsn::TypedSyntaxNode;
     iswarn::Bool, hide_type_stable::Bool, type_annotations::Bool)
     sig, body = children(tsn)
     # We empty the body when filling kwargs
-    istruncated = isempty(children(body))
+    istruncated = is_leaf(body)
     idxend = istruncated ? JuliaSyntax.last_byte(sig) : lastindex(tsn.source)
     if !istruncated # If method only fills in default arguments
         printstyled(io, tsn; type_annotations, iswarn, hide_type_stable, idxend)
@@ -331,7 +331,7 @@ function add_callsites!(d::AbstractDict, visited_cis::AbstractSet, diagnostics::
     isnothing(tsn) && return nothing
     sig, body = children(tsn)
     # We empty the body when filling kwargs
-    istruncated = isempty(children(body))
+    istruncated = is_leaf(body)
     istruncated && return nothing
     # We add new callsites unless we would have multiple callsites for the same source definition,
     # e.g. if f(x) = x is called with different types we print nothing.


### PR DESCRIPTION
#661 was missing these two updates.

Fixes #673.
