### PR TITLE
improve `AsyncIO` robustness

### DIFF
--- a/src/testing.jl
+++ b/src/testing.jl
@@ -109,7 +109,7 @@ function Base.unsafe_read(io::AsyncIO, to::Ptr{UInt8}, nb::UInt)
             splice!(buffer, 1:n)
             written += n
         end
-        eof(io) && throw(EOFError())
+        istaskdone(io.task) && throw(EOFError())
     end
 end
 

--- a/src/testing.jl
+++ b/src/testing.jl
@@ -109,6 +109,7 @@ function Base.unsafe_read(io::AsyncIO, to::Ptr{UInt8}, nb::UInt)
             splice!(buffer, 1:n)
             written += n
         end
+        eof(io) && throw(EOFError())
     end
 end
 


### PR DESCRIPTION
~~- Fix `unsafe_read` to correctly calculate remaining bytes (`nb - written`) and use proper destination offset (`to + written`)~~
~~- Fix potential race condition in `peek` by checking buffer under lock~~

Written with Claude.

EDIT: Turns out I just ended up crafting noises. Picked up one minor improvement from it.