### PR TITLE
Fix UndefVarError in get_exct(::ConcreteCallInfo)

### DIFF
--- a/src/compiler/callsite.jl
+++ b/src/compiler/callsite.jl
@@ -151,7 +151,7 @@ end
 get_ci(ceci::ConcreteCallInfo) = get_ci(ceci.ci)
 get_rt(ceci::ConcreteCallInfo) = get_rt(ceci.ci)
 get_effects(ceci::ConcreteCallInfo) = get_effects(ceci.ci)
-get_exct(cici::ConcreteCallInfo) = get_exct(ceci.ci)
+get_exct(ceci::ConcreteCallInfo) = get_exct(ceci.ci)
 
 struct SemiConcreteCallInfo <: CallInfo
     ci::CallInfo


### PR DESCRIPTION
`get_exct(::ConcreteCallInfo)` binds its argument as `cici` but references `ceci` in the body, so any call throws `UndefVarError: ceci`. The sibling accessors (`get_ci`, `get_rt`, `get_effects`) all use `ceci`.

```julia
julia> cci = Cthulhu.ConcreteCallInfo(Cthulhu.PureCallInfo(Any[], Float64), Any[]);

julia> Cthulhu.get_exct(cci)
ERROR: UndefVarError: `ceci` not defined in `Cthulhu`
```

After this change it returns `Union{}`.

The terminal UI never hits this, since `show_callinfo(::ConcreteCallInfo)` calls `__show_limited` without an `exct` argument — but it is reachable for anything that queries the accessors directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)