### PR TITLE
Make get_effects and get_exct shared generics

### DIFF
--- a/src/CthulhuCompiler.jl
+++ b/src/CthulhuCompiler.jl
@@ -1,6 +1,6 @@
 Base.Experimental.@compiler_options compile=min optimize=1
 
-import .Cthulhu: AbstractProvider, get_abstract_interpreter, get_inference_world, find_method_instance, generate_code_instance, get_override, lookup, find_caller_of, get_inlining_costs, show_parameters, get_ci, get_rt, get_pc_remarks, get_pc_effects, get_pc_excts, show_callsite, show_callinfo, print_callsite_info, cthulhu_source, cthulhu_typed, cthulhu_ast, cthulhu_llvm, cthulhu_native, find_callsites, ir_to_src
+import .Cthulhu: AbstractProvider, get_abstract_interpreter, get_inference_world, find_method_instance, generate_code_instance, get_override, lookup, find_caller_of, get_inlining_costs, show_parameters, get_ci, get_rt, get_pc_remarks, get_pc_effects, get_pc_excts, show_callsite, show_callinfo, print_callsite_info, get_effects, get_exct, cthulhu_source, cthulhu_typed, cthulhu_ast, cthulhu_llvm, cthulhu_native, find_callsites, ir_to_src
 using .Cthulhu: CthulhuState, CthulhuConfig, CallInfo, Callsite, cached_exception_type, get_mi
 
 using Base: isvarargtype, unwrapva, unwrap_unionall, mapany, get_world_counter

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -8,6 +8,8 @@ end
 
 function find_callsites end
 function get_rt end
+function get_effects end
+function get_exct end
 get_ci(c::Callsite) = get_ci(c.info)
 get_mi(c::Callsite) = get_mi(get_ci(c))
 


### PR DESCRIPTION
`src/CthulhuCompiler.jl` imports the `CallInfo` accessors from `Cthulhu` so that both compiler integrations extend the same generic functions — but `get_effects` and `get_exct` are missing from that import list, and `get_effects` is instead defined fresh at the bottom of the file.

Since `CthulhuCompiler.jl` is included once into `Cthulhu` and again into `CthulhuCompilerExt` when `Compiler.AbstractInterpreter !== Base.Compiler.AbstractInterpreter`, this means `Cthulhu.get_effects` and `CthulhuCompilerExt.get_effects` become two distinct functions in that configuration, and `Cthulhu.get_effects(info)` raises a `MethodError` for any `CallInfo` produced by the extension. `get_ci`, `get_rt` and the rest are unaffected because they are imported.

This adds `function get_effects end` / `function get_exct end` next to the existing stubs in `callsite.jl` (they had no owning declaration before) and adds both names to the import list.

No behaviour change in the common case, where `Compiler` reexports `Base.Compiler` and the extension is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)